### PR TITLE
feat!: disallow dunders in study prefixes

### DIFF
--- a/cumulus_library/study_parser.py
+++ b/cumulus_library/study_parser.py
@@ -62,17 +62,21 @@ class StudyManifestParser:
         try:
             with open(f"{study_path}/manifest.toml", encoding="UTF-8") as file:
                 config = toml.load(file)
-                if not config.get("study_prefix") or not isinstance(
-                    config["study_prefix"], str
-                ):
-                    raise StudyManifestParsingError(
-                        f"Invalid prefix in manifest at {study_path}"
-                    )
+                self.validate_study_manifest(config, study_path)
                 self._study_config = config
             self._study_path = study_path
         except FileNotFoundError:
             raise StudyManifestParsingError(  # pylint: disable=raise-missing-from
                 f"Missing or invalid manifest found at {study_path}"
+            )
+
+    @staticmethod
+    def validate_study_manifest(config: dict, study_path: Path) -> None:
+        """Confirm that the study manifest is valid."""
+        prefix = config.get("study_prefix")
+        if not prefix or not isinstance(prefix, str) or "__" in prefix:
+            raise StudyManifestParsingError(
+                f"Invalid prefix in manifest at {study_path}"
             )
 
     def get_study_prefix(self) -> Optional[str]:

--- a/tests/test_data/study_dunder_prefix/manifest.toml
+++ b/tests/test_data/study_dunder_prefix/manifest.toml
@@ -1,0 +1,2 @@
+# We do not allow a double-underscore (dunder) in study names
+study_prefix = "test__dunder"


### PR DESCRIPTION
### Description
Based off a conversation we had about this - figured I'd whip this up.

This allows us to use double underscores (dunders) as separator tokens in tables without fear of collisions.

<!--- Describe your changes in detail -->

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
- [x] Run pylint if you're making changes beyond adding studies