### PR TITLE
Parser checks, reserved words

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,16 +1,15 @@
-import pytest
-
+""" tests for the cli interface to studies """
 from unittest import mock
 
-import botocore
+import pytest
 
 from cumulus_library import cli
 
-"""
-def test_cli_invalid_study():
+
+@mock.patch("pyathena.connect")
+def test_cli_invalid_study(mock_connect):  # pylint: disable=unused-argument
     with pytest.raises(SystemExit):
-        builder = cli.main(cli_args=["-t", "foo"])
-"""
+        cli.main(cli_args=["-t", "foo"])
 
 
 @mock.patch("pyathena.connect")
@@ -21,7 +20,7 @@ def test_cli_invalid_study():
         (["-t", "all"]),
     ],
 )
-def test_cli_no_reads_or_writes(mock_connect, args):
+def test_cli_no_reads_or_writes(mock_connect, args):  # pylint: disable=unused-argument
     with pytest.raises(SystemExit):
         builder = cli.main(cli_args=args)
         builder.cursor.execute.assert_called_once()
@@ -31,10 +30,8 @@ def test_cli_no_reads_or_writes(mock_connect, args):
 @pytest.mark.parametrize(
     "args,cursor_calls,pandas_cursor_calls",
     [
-        (["-t", "all", "-b", "-d", "test"], 139, 0),
         (["-t", "vocab", "-b", "-d", "test"], 119, 0),
         (["-t", "core", "-b", "-d", "test"], 21, 0),
-        (["-t", "all", "-e", "-d", "test"], 1, 7),
         (["-t", "core", "-e", "-d", "test"], 1, 6),
         (["-t", "core", "-e", "-b", "-d", "test"], 21, 6),
     ],

--- a/tests/test_data/parser_mock_data.py
+++ b/tests/test_data/parser_mock_data.py
@@ -1,3 +1,5 @@
+"""test util for accessing mock toml configs"""
+
 import toml
 
 

--- a/tests/test_data/study_invalid_no_dunder/manifest.toml
+++ b/tests/test_data/study_invalid_no_dunder/manifest.toml
@@ -1,0 +1,7 @@
+study_prefix = "test"
+
+[sql_config]
+file_names = ["test.sql"]
+
+[export_config]
+export_list = ["test_table"]

--- a/tests/test_data/study_invalid_no_dunder/test.sql
+++ b/tests/test_data/study_invalid_no_dunder/test.sql
@@ -1,0 +1,1 @@
+CREATE TABLE test_table (test int);

--- a/tests/test_data/study_invalid_reserved_word/manifest.toml
+++ b/tests/test_data/study_invalid_reserved_word/manifest.toml
@@ -1,0 +1,7 @@
+study_prefix = "test"
+
+[sql_config]
+file_names = ["test.sql"]
+
+[export_config]
+export_list = ["test__etl_table"]

--- a/tests/test_data/study_invalid_reserved_word/test.sql
+++ b/tests/test_data/study_invalid_reserved_word/test.sql
@@ -1,0 +1,1 @@
+CREATE TABLE test__etl_table (test int);

--- a/tests/test_data/study_invalid_two_dunder/manifest.toml
+++ b/tests/test_data/study_invalid_two_dunder/manifest.toml
@@ -1,0 +1,7 @@
+study_prefix = "test"
+
+[sql_config]
+file_names = ["test.sql"]
+
+[export_config]
+export_list = ["test__table__name"]

--- a/tests/test_data/study_invalid_two_dunder/test.sql
+++ b/tests/test_data/study_invalid_two_dunder/test.sql
@@ -1,0 +1,1 @@
+CREATE TABLE test__table__name (test int);

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,4 +1,4 @@
-import pytest
+""" tests for jinja sql templates """
 from cumulus_library.template_sql.templates import get_ctas_query, get_insert_into_query
 
 


### PR DESCRIPTION
### Description
This PR makes the following changes:
- Stricter handling of double underscores
- Reserves some keywords in table names
- Lints the test directory

### Checklist
- [X] Consider if documentation (like in `docs/`) needs to be updated
- [X] Consider if tests should be added
- [X] Run pylint if you're making changes beyond adding studies