### PR TITLE
docs: prepare the docs/ folder for ingestion by jekyll

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # project specific
 data_export/
+/.idea/
 .python-version
 .DS_Store
 cumulus_library_columns.json

--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 A framework for designing, executing, and distributing SQL queries packaged as "studies", e.g., for quality monitoring, clinical research, or public health. Part of the [SMART on FHIR Cumulus Project](https://smarthealthit.org/cumulus-a-universal-sidecar-for-a-smart-learning-healthcare-system/)
 
-See [first time setup](./docs/first-time-setup.md) for configuring and running, [creating studies](./docs/creating-studies.md) for using Cumulus Library as part of clinical research, and [core study details](./docs/core-study-details.md) for information about the core dataset.
+For more information, [browse the documentation](https://docs.smarthealthit.org/cumulus/library).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,6 @@
+# Cumulus Library Documentation
+
+These documents are meant to be built as one part of the larger body of
+[Cumulus documentation](https://docs.smarthealthit.org/cumulus).
+
+To test changes here locally, read more at the [Cumulus docs repo](https://github.com/smart-on-fhir/cumulus).

--- a/docs/aws-setup.md
+++ b/docs/aws-setup.md
@@ -1,7 +1,11 @@
-<!-- Target audience: 
-    - clinical researcher, low AWS familiarity
-    - engineer w/ some AWS experience
-reference tone -->
+---
+title: AWS Setup
+parent: Library
+nav_order: 2
+# audience: clinical researcher, low AWS familiarity or engineer w/ some AWS experience
+# type: reference
+---
+
 # AWS setup
 
 Cumulus library executes queries against an 

--- a/docs/core-study-details.md
+++ b/docs/core-study-details.md
@@ -1,4 +1,11 @@
-<!-- intended audience: clinical researchers, IRB reviewers, reference tone-->
+---
+title: Core Study Details
+parent: Library
+nav_order: 4
+# audience: clinical researchers, IRB reviewers
+# type: reference
+---
+
 # Core study details
 
 The core study calculates the **patient count** for every patient group using the [SQL CUBE function](https://prestodb.io/docs/current/sql/select.html#group-by-clause).  

--- a/docs/creating-studies.md
+++ b/docs/creating-studies.md
@@ -1,4 +1,11 @@
-<!-- Target audience: clinical researcher familiar with project, helpful direct tone -->
+---
+title: Creating Library Studies
+parent: Library
+nav_order: 3
+# audience: clinical researcher or engineer familiar with project
+# type: tutorial
+---
+
 # Creating Library Studies
 
 The following guide talks about how to use the Cumulus Library to create new
@@ -6,12 +13,12 @@ aggregations in support of ongoing projects.
 
 ## Forking this repo
 
-We're recommending the Github fork methodology to allow you to stay up to date
+We're recommending the GitHub fork methodology to allow you to stay up to date
 with Cumulus while working on configuring your own projects. 
 
-In the upper right of the Github webpage, you'll see a button labeled `fork`.
+In the upper right of the GitHub webpage, you'll see a button labeled `fork`.
 Click on it, and it will bring you to a page allowing you to configure how your
-copy associated with your github account will work - for most use cases, the
+copy associated with your GitHub account will work - for most use cases, the
 defaults are fine. Click `Create fork` and you'll have your own private copy.
 Use that copy for cloning the code to your personal machine.
 
@@ -98,7 +105,7 @@ styling.
 **Requirements for accepting PRs**
  - **Count tables must use the CUBE function** to create powersets of data. See the
   [CUBE section of groupby](https://prestodb.io/docs/current/sql/select.html#group-by-clause)
-  for more information about this groupby type. The core and template projects
+  for more information about this `groupby` type. The core and template projects
   provide an example of its usage.
   - For PHI reverse identification protection, **exclude rows from count tables if
   they have a small number of members**, i.e. less than 10.
@@ -106,10 +113,10 @@ styling.
 **Recommended**
   - You may want to select a SQL style guide as a reference.
   [Gitlab's data team](https://about.gitlab.com/handbook/business-technology/data-team/platform/sql-style-guide/)
-  has an example of this, though their are other choices.
+  has an example of this, though there are other choices.
   - Don't implicitly reference columns tables. Either use the full table name,
   or give the table an alias, and use that any time you are referencing a column.
-  - Don't use the * wildcard in your final tables. Explictly list the columns
+  - Don't use the * wildcard in your final tables. Explicitly list the columns
   with table name/alias - sqlfluff has a hard time inferring what's going on otherwise.
   - We are currently asking for all caps for sql keywords like SELECT and 4 space
   nesting for queries. `sqlfluff fix` will apply this for you, but it may be easier

--- a/docs/first-time-setup.md
+++ b/docs/first-time-setup.md
@@ -1,10 +1,16 @@
-<!-- Target audience: clinical researcher or engineer familiar with project, working locally, helpful direct tone -->
+---
+title: First Time Setup
+parent: Library
+nav_order: 1
+# audience: clinical researcher or engineer familiar with project, working locally
+# type: howto
+---
 
 # First Time Setup
 
 ## Installation
 
-As a prerequesite, you'll need a copy of python 3.9 or later installed on
+As a prerequisite, you'll need a copy of python 3.9 or later installed on
 your system, and you'll need access to an account with access to AWS cloud services.
 
 If you are using the library just to execute existing studies, you can install
@@ -84,3 +90,7 @@ cnt,influenza_lab_code,influenza_result_display,influenza_test_month
 70,"{code=92141-1, display=Influenza virus B RNA [Presence] in Respiratory specimen by NAA with probe detection, system=http://loinc.org}",,
 69,"{code=92141-1, display=Influenza virus B RNA [Presence] in Respiratory specimen by NAA with probe detection, system=http://loinc.org}",NEGATIVE (QUALIFIER VALUE),
 ```
+
+## Next steps
+
+Now that you are all set up, you can learn how to [create studies](./creating-studies.md) of your own!

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,13 @@
+---
+title: Library
+has_children: true
+# audience: non-technical researcher folks
+---
+
+# Cumulus Library
+
+The Cumulus Library is a framework for designing, executing, and distributing SQL queries
+packaged as "studies", e.g. for quality monitoring, clinical research, or public health.
+
+If you'd like to begin using the Library now,
+start with the [first time setup guide](first-time-setup.md).

--- a/docs/sharing-data.md
+++ b/docs/sharing-data.md
@@ -1,8 +1,11 @@
-<!-- Target audience: 
-    IT security,
-    Clinical researcher
-low to medium familiarity with project
--->
+---
+title: Data Sharing
+parent: Library
+nav_order: 5
+# audience: IT security or clinical researcher with low to medium familiarity with project
+# type: explanation
+---
+
 # Sharing data with third parties
 
 While it is not required if you are using this framework internally to help you manage
@@ -25,14 +28,14 @@ tool of choice.
 
 As part of the Cumulus framework, we have a 
 [middleware application](https://github.com/smart-on-fhir/cumulus-aggregator/) 
-configured to recieve and combine datasets from multiple organizations, which can
+configured to receive and combine datasets from multiple organizations, which can
 then be loaded into the [dashboard](https://github.com/smart-on-fhir/cumulus-app) 
 for SME analysis. As of this writing these are not open source, but are intended
 to be in the near term.
 
 If you are participating in a study using these tools, we provide an
-[upload utility](../data_export/bulk_upload.py) which can handshake with the
-aggregator and upload data to an AWS S3 bucket.
+[upload utility](https://github.com/smart-on-fhir/cumulus-library-core/blob/main/data_export/bulk_upload.py)
+which can handshake with the aggregator and upload data to an AWS S3 bucket.
 
 We recommend configuring the following environment variables for using this script:
 


### PR DESCRIPTION
### Description
The main documentation repo ([smart-on-fhir/cumulus](https://github.com/smart-on-fhir/cumulus)) will use jekyll and GitHub Pages to build docs from this repo and others into one main site.

But in order to do that, we need some little jekyll metadata markers and to organize our docs in a specific way.

- Add docs/index.md (intro) and docs/README.md (dev explainer)
- Add metadata like titles and nav order for all docs

### How this is going to work technically

Right now, the docs site is rebuilt anytime the main docs repo is changed or on a manual request. But eventually, I will add a GitHub action here that will go poke the main docs repo to rebuild itself, if the docs/ folder here changes.

### How this is going to change how we write/edit docs

- Each Cumulus project will have its own little `docs/` fiefdom in its own repo.
  - This way, docs can update as code changes more easily.
- There will be one main docs repo that pulls docs from all the other repos, following certain conventions below.
  - This will also be able to hold certain project-wide docs or cross-repo docs that don't have a natural fit otherwise.

### Draft of document conventions/advice I'm going to put in the main repo

- Everything in `docs/` is going to be accessible on public docs site (direct URL at minimum)
  - Which might affect the tone of your text as well as which files go in there
  - Except for `docs/README.md` which we won't include, so that you can explain what the
    folder is about and point at this repo.
  - Note that this means you can still put sample json, yaml, etc in there.
- Include a `docs/index.md` as your root & intro doc
- Use a toplevel title that makes sense in context of the whole Cumulus project
  - i.e. "Library" instead of "Cumulus Library" probably (though in your doc prose and headers,
    "Cumulus Library" would make sense -- but your main index.md title will be used in the main
    documentation sidebar)
- Use caution when linking:
  - When linking to _code_, use absolute links
  - When linking to other docs _inside_ your repo, use relative links
  - When linking to other docs _outside_ your repo, only link to the following URLs,
    that we promise will exist:
    - https://docs.smarthealthit.org/cumulus/
    - https://docs.smarthealthit.org/cumulus/library/
- Consider audience & tone when editing docs, to help keep a uniform writing style.
  - It can be helpful to consider what [sort of document](https://diataxis.fr/)
    you are writing.

### Pic of how this looks

![Screenshot from 2023-05-10 10-59-10](https://github.com/smart-on-fhir/cumulus-library-core/assets/1196901/51a1da7f-889b-47e6-9c0b-9aff4bc44688)

### Pic of how GitHub renders the metadata

This re-enforces that we can only really have our docs be beautiful in one place, not two - gotta choose the web or GitHub.

![image](https://github.com/smart-on-fhir/cumulus-library-core/assets/1196901/af48b875-b779-4dd0-89c2-47d9d4720a4b)

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
- [x] Run pylint if you're making changes beyond adding studies