### PR TITLE
Added flexible paths & study template

### DIFF
--- a/cumulus_library/cli.py
+++ b/cumulus_library/cli.py
@@ -6,7 +6,7 @@ import os
 import sys
 
 from pathlib import Path, PosixPath
-from typing import Dict
+from typing import Dict, List, Optional
 
 import pyathena
 
@@ -113,73 +113,126 @@ class StudyBuilder:
             self.export_study(study_dict[key])
 
 
-def get_study_dict() -> Dict[str, PosixPath]:
+def get_abs_posix_path(path: str) -> PosixPath:
+    """Conveince method for hanlding abs vs rel paths"""
+    if path[0] == "/":
+        return Path(path)
+    else:
+        return Path(Path.cwd(), path)
+
+
+def create_template(path: str) -> None:
+    """Creates a manifest in target dir if one doesn't exist"""
+    abs_path = get_abs_posix_path(path)
+    manifest_path = Path(abs_path, "manifest.toml")
+    if manifest_path.exists():
+        sys.exit(f"A manifest.toml already exists at {abs_path}, skipping creation")
+    template_path = Path(
+        Path(__file__).resolve().parents[0], "studies/template/manifest.toml"
+    )
+    abs_path.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_bytes(template_path.read_bytes())
+
+
+def get_study_dict(alt_paths: List) -> Optional[Dict[str, PosixPath]]:
     """Convenience function for getting directories in ./studies/
 
     :returns: A list of pathlib.PosixPath objects
     """
     manifest_studies = {}
-    library_path = Path(__file__).resolve().parents[0]
-    for path in Path(f"{library_path}/studies").iterdir():
-        if path.is_dir():
-            manifest_studies[path.name] = path
+    paths = [Path(Path(__file__).resolve().parents[0], "studies")]
+    if alt_paths is not None:
+        paths = paths + alt_paths
+    for parent_path in paths:
+        for child_path in parent_path.iterdir():
+            if child_path.is_dir():
+                manifest_studies[child_path.name] = child_path
+            elif child_path.name == "manifest.toml":
+                manifest_studies[parent_path.name] = parent_path
     return manifest_studies
 
 
 def run_cli(args: Dict):  # pylint: disable=too-many-branches
     """Controls which library tasks are run based on CLI arguments"""
-    builder = StudyBuilder(
-        args["s3_bucket"],
-        args["region"],
-        args["workgroup"],
-        args["profile"],
-        args["database"],
-    )
-    if args["verbose"]:
-        builder.verbose = True
+    if not args["build"] and not args["export"] and not args["create"]:
+        sys.exit(
+            (
+                "Expecting at least one of build, export or create as arguments. "
+                "See `cumulus_library --help` for more information"
+            )
+        )
 
-    # here we invoke the cursor once to confirm valid connections
-    builder.cursor.execute("show tables")
+    if args["create"]:
+        create_template(args["path"])
 
-    if not args["build"] and not args["export"]:
-        sys.exit("Neither build nor export specified - exiting with no action")
-    study_dict = get_study_dict()
+    if args["build"] or args["export"]:
+        builder = StudyBuilder(
+            args["s3_bucket"],
+            args["region"],
+            args["workgroup"],
+            args["profile"],
+            args["database"],
+        )
+        if args["verbose"]:
+            builder.verbose = True
 
-    if args["build"]:
-        if "all" in args["target"]:
-            builder.clean_and_build_all(study_dict)
-        else:
-            for target in args["target"]:
-                if target in study_dict:
-                    builder.clean_and_build_study(study_dict[target])
+        study_dict = get_study_dict(args["study_dir"])
+        # here we invoke the cursor once to confirm valid connections
+        builder.cursor.execute("show tables")
 
-    if args["export"]:
-        if "all" in args["target"]:
-            builder.export_all(study_dict)
-        else:
-            for target in args["target"]:
-                builder.export_study(study_dict[target])
+        if args["build"]:
+            if "all" in args["target"]:
+                builder.clean_and_build_all(study_dict)
+            else:
+                for target in args["target"]:
+                    if target in study_dict:
+                        builder.clean_and_build_study(study_dict[target])
 
-    # returning the builder for ease of unit testing
-    return builder
+        if args["export"]:
+            if "all" in args["target"]:
+                builder.export_all(study_dict)
+            else:
+                for target in args["target"]:
+                    builder.export_study(study_dict[target])
+
+        # returning the builder for ease of unit testing
+        return builder
 
 
 def get_parser():
     """Provides parser for handling CLI arguments"""
     parser = argparse.ArgumentParser(
-        description="""Generates study views from post-Cumulus ETL data.
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description="""Generates study tables and views from post-Cumulus ETL data.
 
-        By default, make will remove, and recreate, all table views, assuming
-        you have set the required  credentials, which are used in the following
-        order of preference:
-        - explict command line arguments
-        - cumulus environment variables (CUMULUS_LIBRARY_PROFILE,
-        CUMULUS_LIBRARY_SCHEMA, CUMULUS_LIBRARY_S3, CUMULUS_LIBRARY_REGION)
-        - Normal boto profile order (AWS env vars, ~/.aws/credentials, ~/.aws/config)
-        connecting to AWS. Passing values via the command line will override the
-        environment variables """
+cumulus_library will attempt to create a connection to AWS athena. The
+following order of preference is used to select credentials:
+  - explict command line arguments
+  - cumulus environment variables (CUMULUS_LIBRARY_PROFILE, 
+    CUMULUS_LIBRARY_SCHEMA, CUMULUS_LIBRARY_S3, CUMULUS_LIBRARY_REGION)
+  - Normal boto profile order (AWS env vars, ~/.aws/credentials, ~/.aws/config)""",
     )
-    parser.add_argument(
+
+    studygen = parser.add_argument_group("Creating study templates")
+    studygen.add_argument(
+        "-c",
+        "--create",
+        action="store_true",
+        default=False,
+        help=("Create a study instance from a template"),
+    )
+    studygen.add_argument(
+        "-p",
+        "--path",
+        default="./",
+        help=(
+            "The the directory the study will be created in. Default is "
+            "the current directory."
+        ),
+    )
+
+    db = parser.add_argument_group("SQL database modifications")
+    db.add_argument(
         "-t",
         "--target",
         action="append",
@@ -188,21 +241,33 @@ def get_parser():
             "build all studies."
         ),
     )
-    parser.add_argument(
+    db.add_argument(
+        "-s",
+        "--study_dir",
+        action="append",
+        help=(
+            "Add one or more directories to look for study definitions in. "
+            "Default is in project directory and CUMULUS_LIBRARY_PATH, if present, "
+            "followed by any supplied paths. Target, and all its subdirectories, "
+            "are checked for manifests. Overriding studies with the same namespace "
+            "supercede eariler ones."
+        ),
+    )
+    db.add_argument(
         "-b",
         "--build",
         default=False,
         action="store_true",
-        help=("Recreates Athena views from sql definitions"),
+        help=("Removes and recreates Athena tables & views for the specified studies"),
     )
-    parser.add_argument(
+    db.add_argument(
         "-e",
         "--export",
         default=False,
         action="store_true",
-        help=("Generates files on disk from Athena views"),
+        help=("Generates files on disk from Athena views for the specified studies"),
     )
-    parser.add_argument(
+    db.add_argument(
         "-v",
         "--verbose",
         default=False,
@@ -211,23 +276,20 @@ def get_parser():
     )
 
     aws = parser.add_argument_group("AWS config")
-    aws.add_argument("-p", "--profile", help="AWS profile", default="default")
-    aws.add_argument("-d", "--database", help="Cumulus ETL Athena DB/schema")
+    aws.add_argument("--profile", help="AWS profile", default="default")
+    aws.add_argument("--database", help="Cumulus ETL Athena DB/schema")
     aws.add_argument(
-        "-w",
         "--workgroup",
         default="cumulus",
         help="Cumulus Athena workgroup (default: cumulus)",
     )
     aws.add_argument(
-        "-s",
         "--s3_bucket",
         help=(
             "S3 location to store athena metadata. " "(will contain some query outputs)"
         ),
     )
     aws.add_argument(
-        "-r",
         "--region",
         help="AWS region data of Athena instance (default: us-east-1)",
         default="us-east-1",
@@ -240,6 +302,7 @@ def main(cli_args=None):
     """Reads CLI input/environment variables and invokes library calls"""
     parser = get_parser()
     args = vars(parser.parse_args(cli_args))
+
     if args["target"] is not None:
         for target in args["target"]:
             if target == "all":
@@ -247,6 +310,13 @@ def main(cli_args=None):
                 break
     else:
         args["target"] = ["all"]
+
+    if args["study_dir"] is not None:
+        posix_paths = []
+        for path in args["study_dir"]:
+            posix_paths.append(get_abs_posix_path(path))
+        args["study_dir"] = posix_paths
+
     if profile_env := os.environ.get("CUMULUS_LIBRARY_PROFILE"):
         args["profile"] = profile_env
     if database_env := os.environ.get("CUMULUS_LIBRARY_SCHEMA"):
@@ -257,6 +327,8 @@ def main(cli_args=None):
         args["s3_bucket"] = bucket_env
     if region_env := os.environ.get("CUMULUS_LIBRARY_REGION"):
         args["region"] = region_env
+    if path_dir := os.environ.get("CUMULUS_LIBRARY_PATH"):
+        args["path"] = [path_dir] + args["path"]
 
     return run_cli(args)
 

--- a/cumulus_library/studies/template/manifest.toml
+++ b/cumulus_library/studies/template/manifest.toml
@@ -1,8 +1,3 @@
-# If you'd like to run this template study as a proof of concept, you can load
-# the 1000 patient synthea cohort from: 
-#    https://github.com/smart-on-fhir/sample-bulk-fhir-datasets
-# into you database, and it will generate a very small count dataset
-
 # 'study_prefix' should be a string at the start of each table. We'll use this
 # to clean up queries, so it should be unique. Name your tables in the following
 # format: [study_prefix]__[table_name]. It should probably, but not necessarily,

--- a/cumulus_library/study_parser.py
+++ b/cumulus_library/study_parser.py
@@ -163,7 +163,7 @@ class StudyManifestParser:
 
         # We'll do a pass to see if any of these tables were created outside of a
         # study builder, and remove them from the list.
-        for view_table in view_table_list:
+        for view_table in view_table_list.copy():
             if any(
                 view_table[0].startswith(f"{self.get_study_prefix()}__{word}_")
                 for word in RESERVED_TABLE_KEYWORDS

--- a/docs/creating-studies.md
+++ b/docs/creating-studies.md
@@ -11,33 +11,30 @@ nav_order: 3
 The following guide talks about how to use the Cumulus Library to create new
 aggregations in support of ongoing projects.
 
-## Forking this repo
+## Setup
 
-We're recommending the GitHub fork methodology to allow you to stay up to date
-with Cumulus while working on configuring your own projects. 
+If you are going to be creating new studies, we strongly recommend adding an
+environment variable, `CUMULUS_LIBRARY_PATH`, pointing to the folder in which 
+you'll be working on study development. `cumulus-library` will look in each 
+subdirectory of that folder for manifest files, so you can run several studies
+at once. 
 
-In the upper right of the GitHub webpage, you'll see a button labeled `fork`.
-Click on it, and it will bring you to a page allowing you to configure how your
-copy associated with your GitHub account will work - for most use cases, the
-defaults are fine. Click `Create fork` and you'll have your own private copy.
-Use that copy for cloning the code to your personal machine.
-
-If there are new commits to the primary Cumulus Library repo, you'll see a note
-about this just under the green `Code` button - you can click `sync fork` to get
-any changes and apply them to your copy, after which you can pull them down to
-machines your team is using to develop.
+If you're not doing this, you can always add the `--study_dir path/to/dir` argument
+to any build/export call to tell it where to look for your work.
 
 ## Creating a new study
 
-Studies are automatically detected by Cumulus Library when they are placed in the
-`/cumulus-library/studies` directory, assuming they have a manifest file. The
-easiest way to make a new study is to copy the template study to a new directory,
-which you can do via the command line or via your system's file system GUI, and
-rename the folder to something relevant to your study (we'll use `my_study` for
-this document. The folder name is the same thing you will supply to the
-`cumulus-library` command as a target when you want to bulk update data.
+The easiest way to get started with a new study is to use `cumulus-library` to
+create a manifest for you. You can do this with by running:
+```bash
+cumulus-library -c -p ./path/to/your/study/dir
+```
+We'll create that folder if it doesn't already exist. We recommend you use a name
+relevant to your study (we'll use `my_study` forthis document). The folder name is
+the same thing you will use as a target with `cumulus_library` to run your study's
+queries.
 
-Once you've made a new study, the `manifest.toml` is the place you let cumulus
+Once you've made a new study, the `manifest.toml` fiile is the place you let cumulus
 library know how you want your study to be run against the remote database. The
 template manifest has comments describing all the possible configuration parameters
 you can supply, but for most studies you'll have something that looks like this:
@@ -71,6 +68,9 @@ Talking about what these three sections do:
   counts to reduce exposure of limited datasets, and so we recommend only exporting
   count tables.
 
+We recommend creating a git repo per study, to help version your study data, which
+you can do in the same directory as the manifest file.
+
 ### Writing SQL queries
 
 Most users have a workflow that looks like this:
@@ -80,8 +80,13 @@ Most users have a workflow that looks like this:
   - Build your study with the CLI to make sure your queries load correctly.
 
 We use [sqlfluff](https://github.com/sqlfluff/sqlfluff) to help maintain a consistent
-style across many different SQL query authors. There are two commands you may want to
-run inside your study's directory:
+style across many different SQL query authors. You don't have to if you are working
+on development, but if you're going to submit your study when completed back to
+the Cumulus project, it may be worth mimicing our linting strategy. You can copy our 
+[sqlfluff configuration rules](https://github.com/smart-on-fhir/cumulus-library-core/blob/main/pyproject.toml)
+into your study directory to configure the right behavior.
+
+There are two commands you may want to run inside your study's directory:
   - `sqlfluff lint` will show you any variations from the expected styling rules
   - `sqlfluff fix` will try to make your autocorrect your queries to match the
   expected style
@@ -130,7 +135,9 @@ styling.
 
 ## Sharing studies
 
-If you want to share your study as part of a publication, you can open a PR - one
-of the optional targets will be the main `cumulus-library-core` repo, and the
-maintainers will be notified of it. If you write a paper using the Cumulus library,
-please cite us.
+If you want to share your study as part of a publication, you'll need to open a PR - 
+after cloning this repository, make a branch, and add your study config to the
+`cumulus_library/studies/` directory, and then just open a PR. 
+
+If you write a paper using the Cumulus library, please 
+[cite the project](https://smarthealthit.org/cumulus-a-universal-sidecar-for-a-smart-learning-healthcare-system/)

--- a/docs/first-time-setup.md
+++ b/docs/first-time-setup.md
@@ -27,8 +27,11 @@ services. See the [AWS setup guide](./aws-setup.md) for more information on this
 ## Command line usage
 
 Installing adds a `cumulus-library` command for interacting with
-athena. There are two primary modes most users will be interested in:
+athena. There are three primary modes most users will be interested in:
 
+- `--create` will create a manifest file for you so you can start working on
+authoring queires (more information on this in 
+[Creating studies](./creating-studies.md)).
 - `--build` will create new study tables, replacing previously created versions
 (more information on this in [Creating studies](./creating-studies.md)).
 - `--export` will output the data in the tables to both a `.csv` and
@@ -36,7 +39,7 @@ athena. There are two primary modes most users will be interested in:
 more compressed and should be preferred (if supported) for use when transmitting
 data/loading data into analytics packages.
 
-By default, all available studies will be used by these commands, but you can use
+By default, all available studies will be used by build and export., but you can use
 or `--target` to specify a specific study to be run. You can use it multiple
 times to configure several studies in order. The `vocab`, in particular, can take a
 bit of time to generate, so we recommend using targets after your initial configuration.
@@ -57,8 +60,8 @@ deploy in Amazon's US-East zone.
 study creates mappings of system codes to strings, and the `core` study creates
 tables for commonly used base FHIR resources like `Patient` and `Observation`
 using that vocab. To do this, run the following command:
-```
-./cumulus_library/cli.py --build --target vocab --target core
+```bash
+cumulus-library --build --target vocab --target core
 ```
 This usually takes around five minutes, but once it's done, you won't need build
 `vocab` again unless there's a coding system addition, and you'll only need to build
@@ -70,14 +73,14 @@ Creating vocab study in db... ━━━━━━━━━━━━━━━━�
 Creating core study in db... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
 ```
 - Now, we'll build the template study. Run a very similar command to target `template`:
-```
-./cumulus_library/cli.py --build --target template
+```bash
+cumulus-library --build --target template
 ```
 This should be much faster - these tables will be created in around 15 seconds.
 - You can use the AWS Athena console to view these tables directly, but you can also
 download designated study artifacts. To do the latter, run the following command:
-```
-./cumulus_library/cli.py --build --target export
+```bash
+cumulus-library --build --target export
 ```
 And this will download some example count aggregates to the `data_export` directory
 inside of this repository. There's only a few bins, but this will give you an idea


### PR DESCRIPTION
### Description
This PR makes the following changes:
- Adds a new CLI option for quick creation of manifest templates
- Adds a new CLI option for adding paths for studies
- Removes shortcut options for config items which are ususally specified by environment variable

### Checklist
- [X] Consider if documentation (like in `docs/`) needs to be updated
- [X] Consider if tests should be added
- [X] Run pylint if you're making changes beyond adding studies