### PR TITLE
feat!: update some CLI arguments / env variables for consistency

### DIFF
--- a/cumulus_library/study_parser.py
+++ b/cumulus_library/study_parser.py
@@ -140,7 +140,7 @@ class StudyManifestParser:
         additional ways to get a list of table prefixes
         """
         if not schema_name:
-            raise ValueError("No schema name provided")
+            raise ValueError("No database provided")
         prefix = self.get_study_prefix()
         view_sql = get_show_views(schema_name, prefix)
         table_sql = get_show_tables(schema_name, prefix)

--- a/docs/aws-setup.md
+++ b/docs/aws-setup.md
@@ -45,12 +45,9 @@ variables containing your credential information. The relevant ones are:
 unless your organization is using advanced credential management.)
 - `CUMULUS_LIBRARY_REGION` : The AWS region your bucket is in (e.g., us-east-1)
 
-In both cases, there are several additional parameters you will need to configure
-to specify where your database information lives. Unless you are using multiple
-library instances, you will want to specify these values  
-- `CUMULUS_LIBRARY_SCHEMA` : The name of the schema Athena will use ('cumulus_library_sample_db' if using the sample DB)
-- `CUMULUS_LIBRARY_S3` : The URL of your S3 bucket 
-  ('s3://cumulus_library_sample_db-(AWS account ID)-(AWS region)' if using sample db)
-- `CUMULUS_LIBRARY_PROFILE` : the Athena profile to execute queries in ('cumulus_library_sample_db' if using the sample DB)
+There are several additional parameters you will need to configure
+to specify where your database information lives:
+- `CUMULUS_LIBRARY_DATABASE` : The name of the database Athena will use (`cumulus_library_sample_db` if using the sample DB)
+- `CUMULUS_LIBRARY_WORKGROUP` : the Athena workgroup to execute queries in (`cumulus_library_sample_db` if using the sample DB)
 
 Configuring environment variables on your system is out of scope of this document, but several guides are available elsewhere. [This guide](https://www.twilio.com/blog/2017/01/how-to-set-environment-variables.html), for example, covers Mac, Windows, and Linux. And, as a plus, it has a picture of an adorable puppy at the top of it.

--- a/docs/first-time-setup.md
+++ b/docs/first-time-setup.md
@@ -59,8 +59,8 @@ cumulus-library --build --target vocab --target core
 ```
 This usually takes around five minutes, but once it's done, you won't need build
 `vocab` again unless there's a coding system addition, and you'll only need to build
-`core` again if data changes (and only if you're using the synthetic dataset). You
-should see some progress bars like this while the tables are being created:
+`core` again if data changes.
+You should see some progress bars like this while the tables are being created:
 ```
 Uploading vocab__icd data... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╸ 100% 0:00:00
 Creating vocab study in db... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ Source = "https://github.com/smart-on-fhir/cumulus-library-core"
 
 
 [project.scripts]
-cumulus-library = "cumulus_library.cli:main"
+cumulus-library = "cumulus_library.cli:main_cli"
 
 [build-system]
 requires = ["flit_core >=3.4,<4"]


### PR DESCRIPTION
### Description
- Rename `--study_dir` to `--study-dir`
- Drop the S3 bucket gathering entirely, we can get it from workgroup
- Rename `CUMULUS_LIBRARY_SCHEMA` to `CUMULUS_LIBRARY_DATABASE`
- Mention `CUMULUS_LIBRARY_WORKGROUP` in the docs

I could add some safety fallbacks for old env names, if you like the renames, but feel they are too jarring / sudden.

<!--- Describe your changes in detail -->

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
- [x] Run pylint if you're making changes beyond adding studies