### PR TITLE
Undo linter overcorrection

### DIFF
--- a/cumulus_library/template_sql/extension_denormalize.sql.jinja
+++ b/cumulus_library/template_sql/extension_denormalize.sql.jinja
@@ -11,8 +11,8 @@ CREATE TABLE {{ target_table }} AS (
             ext_child.ext.valuecoding.display AS {{ target_col_prefix }}_display
         FROM
             {{ source_table }} AS s,
-            UNNEST(extension),
-            UNNEST(ext_parent.ext.extension)
+            UNNEST(extension) AS ext_parent (ext), --noqa: AL05
+            UNNEST(ext_parent.ext.extension) AS ext_child (ext) --noqa: AL05
         WHERE
             ext_parent.ext.url = '{{ fhir_extension }}'
             AND ext_child.ext.url = '{{ system }}'

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -54,8 +54,8 @@ def test_extension_denormalize_creation():
             ext_child.ext.valuecoding.display AS prefix_display
         FROM
             source_table AS s,
-            UNNEST(extension),
-            UNNEST(ext_parent.ext.extension)
+            UNNEST(extension) AS ext_parent (ext), --noqa: AL05
+            UNNEST(ext_parent.ext.extension) AS ext_child (ext) --noqa: AL05
         WHERE
             ext_parent.ext.url = 'fhir_extension'
             AND ext_child.ext.url = 'omb'
@@ -71,8 +71,8 @@ def test_extension_denormalize_creation():
             ext_child.ext.valuecoding.display AS prefix_display
         FROM
             source_table AS s,
-            UNNEST(extension),
-            UNNEST(ext_parent.ext.extension)
+            UNNEST(extension) AS ext_parent (ext), --noqa: AL05
+            UNNEST(ext_parent.ext.extension) AS ext_child (ext) --noqa: AL05
         WHERE
             ext_parent.ext.url = 'fhir_extension'
             AND ext_child.ext.url = 'text'
@@ -129,5 +129,4 @@ def test_extension_denormalize_creation():
         ["omb", "text"],
     )
     query = get_extension_denormalize_query(config)
-    print(query)
     assert query == expected


### PR DESCRIPTION
### Description
This PR makes the following chage:
- SqlFluff trims out names of unnests that are used in a where clause, but not in the query itself. This undoes that correction and adds an ignore which should prevent it from happening in the future.

### Checklist
- [X] Consider if documentation (like in `docs/`) needs to be updated
- [X] Consider if tests should be added
- [X] Run pylint if you're making changes beyond adding studies