### PR TITLE
Limited CI runs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-
+This PR makes the following changes:
 
 ### Checklist
 - [ ] Consider if documentation (like in `docs/`) needs to be updated

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,3 @@
-This PR makes the following changes:
 
 ### Checklist
 - [ ] Consider if documentation (like in `docs/`) needs to be updated

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,4 @@
-### Description
-<!--- Describe your changes in detail -->
+
 
 ### Checklist
 - [ ] Consider if documentation (like in `docs/`) needs to be updated

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,18 @@
 name: CI
-on: [push]
+on:
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'docs/**'
+
+# The goal here is to cancel older workflows when a PR is updated (because it's pointless work)
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
 jobs:
   unittest:
     name: unit tests

--- a/docs/study-list.md
+++ b/docs/study-list.md
@@ -1,3 +1,11 @@
+---
+title: Cumulus studies
+parent: Library
+nav_order: 6
+# audience: Clinical researchers interested in publications
+# type: reference
+---
+
 # Cumulus studies
 
 ## Smart managed studies


### PR DESCRIPTION
This PR makes the following changes:
- Limits CI runs to just PRs and interrupts runs, and excludes markdown updates
- Trims PR template as an excuse to test the above

### Checklist
- [X] Consider if documentation (like in `docs/`) needs to be updated
- [X] Consider if tests should be added
- [X] Run pylint if you're making changes beyond adding studies